### PR TITLE
Make SystemGenerator able to handle both periodic and non-periodic Topology objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,10 +234,12 @@ Parameterized molecules are cached in `db.json`.
 Parameters for multiple force fields can be held in the same cache file.
 
 By default, `SystemGenerator` will use `PME` for periodic systems and `NoCutoff` for non-periodic systems.
-You can modify this behavior with the optional `periodic_nonbonded_method` and `nonperiodic_nonbonded_method` arguments:
+You can modify this behavior with the optional `periodic_forcefield_kwargs` and `nonperiodic_forcefield_kwargs` arguments, which are used to update `forcefield_kwargs` depending on whether the system is periodic or non-periodic:
 ```python
 from simtk.openmm import app
-system_generator = SystemGenerator(forcefields=['amber/ff14SB.xml', 'amber/tip3p_standard.xml'], periodic_nonbonded_method=app.LJPME, nonperiodic_nonbonded_method=app.CutoffNonPeriodic)
+system_generator = SystemGenerator(forcefields=['amber/ff14SB.xml', 'amber/tip3p_standard.xml'],
+    periodic_forcefield_kwargs={'nonbondedMethod' : app.LJPME},
+    nonperiodic_forcefield_kwargs={'nonbondedMethod' : app.CutoffNonPeriodic})
 ```
 
 To use the [Open Force Field `openff-1.0.0` ("Parsley") force field](https://openforcefield.org/news/introducing-openforcefield-1.0/) instead of GAFF 2.11, we would have instead specified `small_molecule_forcefield='openff-1.0.0'`.

--- a/README.md
+++ b/README.md
@@ -221,8 +221,7 @@ Here's an example that uses GAFF 2.11 along with the new `ff14SB` generation of 
 # Define the keyword arguments to feed to ForceField
 from simtk import unit
 from simtk.openmm import app
-forcefield_kwargs = { 'constraints' : app.HBonds, 'rigidWater' : True, 'removeCMMotion' : False,
-                      'nonbondedMethod' : app.PME, 'hydrogenMass' : 4*unit.amu }
+forcefield_kwargs = { 'constraints' : app.HBonds, 'rigidWater' : True, 'removeCMMotion' : False, 'hydrogenMass' : 4*unit.amu }
 # Initialize a SystemGenerator using GAFF
 from openmmforcefields.generators import SystemGenerator
 system_generator = SystemGenerator(forcefields=['amber/ff14SB.xml', 'amber/tip3p_standard.xml'], small_molecule_forcefield='gaff-2.11', forcefield_kwargs=forcefield_kwargs, cache='db.json')
@@ -233,6 +232,13 @@ system = system_generator.create_system(openmm_topology, molecules=molecules)
 ```
 Parameterized molecules are cached in `db.json`.
 Parameters for multiple force fields can be held in the same cache file.
+
+By default, `SystemGenerator` will use `PME` for periodic systems and `NoCutoff` for non-periodic systems.
+You can modify this behavior with the optional `periodic_nonbonded_method` and `nonperiodic_nonbonded_method` arguments:
+```python
+from simtk.openmm import app
+system_generator = SystemGenerator(forcefields=['amber/ff14SB.xml', 'amber/tip3p_standard.xml'], periodic_nonbonded_method=app.LJPME, nonperiodic_nonbonded_method=app.CutoffNonPeriodic)
+```
 
 To use the [Open Force Field `openff-1.0.0` ("Parsley") force field](https://openforcefield.org/news/introducing-openforcefield-1.0/) instead of GAFF 2.11, we would have instead specified `small_molecule_forcefield='openff-1.0.0'`.
 

--- a/README.md
+++ b/README.md
@@ -261,10 +261,11 @@ See the corresponding directories for information on how to use the provided con
 
 ## 0.6.1 Updated README and minor bugfixes
 
-* Fix examples in the README
+* Fix examples in the `README.md`
 * Fix `GAFFTemplateGenerator.gaff_major_version`
 * Fix incorrect default SMIRNOFF force field, which is now `openff-1.0.0` (was previously `smirnoff99Frosst-1.1.0`)
 * Add `SystemGenerator.SMALL_MOLECULE_FORCEFIELDS` convenience property to list available small molecule force fields
+* `SystemGenerator` API changed to support both periodic and non-periodic `Topology` objects for the same generator
 
 ## 0.6.0 Updated AMBER force fields (AmberTools 19.9) and small molecule support via GAFF
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ To use the [Open Force Field `openff-1.0.0` ("Parsley") force field](https://ope
 
 **Q:** What is the minimum version of OpenMM required to use this package?
 <br>
-**A:** You need at least OpenMM 7.4.1 to use the `openmm-forcefields` package.
+**A:** You need at least OpenMM 7.5.0 to use the `openmm-forcefields` package.
 
 **Q:** Do you support the new [Amber ff19SB protein force field](https://chemrxiv.org/articles/ff19SB_Amino-Acid_Specific_Protein_Backbone_Parameters_Trained_Against_Quantum_Mechanics_Energy_Surfaces_in_Solution/8279681/1)?
 <br>

--- a/openmmforcefields/generators/system_generators.py
+++ b/openmmforcefields/generators/system_generators.py
@@ -10,6 +10,8 @@ System generators that build an OpenMM System object from a Topology object.
 import logging
 _logger = logging.getLogger("perses.forcefields.system_generators")
 
+from simtk.openmm import app
+
 ################################################################################
 # System generator base class
 ################################################################################
@@ -53,7 +55,7 @@ class SystemGenerator(object):
     postprocess_system : method
         If not None, this method will be called as ``system = postprocess_system(system)`` to post-process the System object for create_system(topology) before it is returned.
     """
-    def __init__(self, forcefields=None, small_molecule_forcefield='openff-1.0.0', forcefield_kwargs=None, barostat=None, molecules=None, cache=None, postprocess_system=None):
+    def __init__(self, forcefields=None, small_molecule_forcefield='openff-1.0.0', forcefield_kwargs=None, periodic_nonbonded_method=app.PME, nonperiodic_nonbonded_method=app.NoCutoff, barostat=None, molecules=None, cache=None, postprocess_system=None):
         """
         This is a utility class to generate OpenMM Systems from Open Force Field Topology objects using AMBER
         protein force fields and GAFF small molecule force fields.
@@ -73,6 +75,10 @@ class SystemGenerator(object):
             (See ``SMIRNOFFTemplateGenerator.INSTALLED_FORCEFIELDS`` for a complete list.)
         forcefield_kwargs : dict, optional, default=None
             Keyword arguments to be passed to ``simtk.openmm.app.ForceField.createSystem()`` during ``System`` object creation.
+        periodic_nonbonded_method : NonbondedMethod, optional, default=PME
+            The nonbonded method from ``simtk.openmm.app`` to use for periodic Topology objects; one of [``PME``, ``LJPME``, ``CustoffPeriodic``]
+        nonperiodic_nonbonded_method : NonbondedMethod, optional, default=NoCutoff
+            The nonbonded method from ``simtk.openmm.app`` to use for non-periodic Topology objects; one of [``NoCutoff``, ``CutoffNonPerodic``]
         barostat : simtk.openmm.MonteCarloBarostat, optional, default=None
             If not None, a new ``MonteCarloBarostat`` with matching parameters (but a different random number seed) will be created and
             added to each newly created ``System``.
@@ -104,8 +110,7 @@ class SystemGenerator(object):
         >>> from openmmforcefields.generators import SystemGenerator
         >>> amber_forcefields = ['amber/protein.ff14SB.xml', 'amber/tip3p_standard.xml', 'amber/tip3p_HFE_multivalent.xml']
         >>> small_molecule_forcefield = 'gaff-2.11'
-        >>> forcefield_kwargs = { 'constraints' : app.HBonds, 'rigidWater' : True, 'removeCMMotion' : False,
-        ... 'nonbondedMethod' : app.PME, 'hydrogenMass' : 4*unit.amu }
+        >>> forcefield_kwargs = { 'constraints' : app.HBonds, 'rigidWater' : True, 'removeCMMotion' : False, 'hydrogenMass' : 4*unit.amu }
         >>> system_generator = SystemGenerator(forcefields=amber_forcefields, small_molecule_forcefield=small_molecule_forcefield, forcefield_kwargs=forcefield_kwargs)
 
         If the ``cache`` argument is specified, parameterized molecules are cached in the corresponding file.
@@ -162,6 +167,8 @@ class SystemGenerator(object):
 
         # Cache force fields and settings to use
         self.forcefield_kwargs = forcefield_kwargs if forcefield_kwargs is not None else dict()
+        self.periodic_nonbonded_method = periodic_nonbonded_method
+        self.nonperiodic_nonbonded_method = nonperiodic_nonbonded_method
 
         # Create and cache a residue template generator
         from openmmforcefields.generators.template_generators import SmallMoleculeTemplateGenerator
@@ -288,8 +295,16 @@ class SystemGenerator(object):
         if (self.template_generator is not None) and (molecules is not None):
             self.template_generator.add_molecules(molecules)
 
+        # Build the kwargs to use
+        import copy
+        forcefield_kwargs = copy.deepcopy(self.forcefield_kwargs)
+        if topology.getPeriodicBoxVectors() is None:
+            forcefield_kwargs['nonbondedMethod'] = self.nonperiodic_nonbonded_method
+        else:
+            forcefield_kwargs['nonbondedMethod'] = self.periodic_nonbonded_method
+                        
         # Build the System
-        system = self.forcefield.createSystem(topology, **self.forcefield_kwargs)
+        system = self.forcefield.createSystem(topology, **forcefield_kwargs)
 
         # Modify other forces as requested
         self._modify_forces(system)

--- a/openmmforcefields/tests/test_system_generator.py
+++ b/openmmforcefields/tests/test_system_generator.py
@@ -185,8 +185,8 @@ class TestSystemGenerator(unittest.TestCase):
                 generator = SystemGenerator(forcefields=self.amber_forcefields,
                                                 small_molecule_forcefield=small_molecule_forcefield,
                                                 forcefield_kwargs=forcefield_kwargs,
-                                                periodic_nonbonded_method=app.LJPME,
-                                                nonperiodic_nonbonded_method=app.CutoffNonPeriodic,
+                                                periodic_forcefield_kwargs={'nonbondedMethod':app.LJPME},
+                                                nonperiodic_forcefield_kwargs={'nonbondedMethod':app.CutoffNonPeriodic},
                                                 molecules=molecules)
 
                 # Parameterize molecules


### PR DESCRIPTION
Addresses #93 

This PR allows a single `SystemGenerator` object to handle both periodic and non-periodic `Topology` objects, where the `nonbondedMethod` is controlled by `periodic_nonbonded_method` and `nonperiodic_nonbonded_method`.