### PR TITLE
Add draft implementation of user-specified charges

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,17 @@ Because the [OpenMM `Topology` object](http://docs.openmm.org/latest/api-python/
 To do this, it is necessary to specify one or more [`openforcefield.topology.Molecule`](https://open-forcefield-toolkit.readthedocs.io/en/latest/api/generated/openforcefield.topology.Molecule.html#openforcefield.topology.Molecule) objects which can easily be created from many different representations of small molecules, including SMILES strings and common molecule storage formats.
 There are many ways to create an [openforcefield `Molecule` object](https://open-forcefield-toolkit.readthedocs.io/en/latest/api/generated/openforcefield.topology.Molecule.html#openforcefield.topology.Molecule) from various file formats as well---see the [API docs](https://open-forcefield-toolkit.readthedocs.io/en/latest/api/generated/openforcefield.topology.Molecule.html#openforcefield.topology.Molecule) for more details.
 
-The `openforcefield` toolkit charging method [`Molecule.compute_partial_charges_am1bcc`](https://open-forcefield-toolkit.readthedocs.io/en/latest/api/generated/openforcefield.topology.Molecule.html#openforcefield.topology.Molecule.compute_partial_charges_am1bcc) is used to assign partial charges.
+### Partial charges for small molecules
+
+If the provided molecule(s) contain nonzero (user-specified) partial charges, they will be used.
+If they do _not_ contain partial charges, the `openforcefield` toolkit charging method [`Molecule.compute_partial_charges_am1bcc`](https://open-forcefield-toolkit.readthedocs.io/en/latest/api/generated/openforcefield.topology.Molecule.html#openforcefield.topology.Molecule.compute_partial_charges_am1bcc) is used to assign partial charges.
 The [canonical AM1-BCC charging method](https://docs.eyesopen.com/toolkits/cookbook/python/modeling/am1-bcc.html) is used to assign ELF10 charges if the OpenEye Toolkit is available.
 If not, [Antechamber](http://ambermd.org/antechamber/) from the [AmberTools](http://ambermd.org/AmberTools.php) distribution (which uses the `sqm` semiempirical quantum chemical package) is used to assign AM1-BCC charges (`antechamber -c bcc`).
 
 *Note:* The `Molecule` object must have the all protons and stereochemistry explicitly specified, and must match the exact protonation and tautomeric state of the molecule that will be found in your OpenMM `Topology` object.
 The atom ordering need not be the same.
+
+*Note:* The first time a `Molecule` is specified, added, or cached, if it lacks partial charges, the automatically generated charges will be cached and reused; if it contains user-specified partial charges, those charges will be used and cached. Adding the molecule again with a different set of charges will have no effect on changing which charges are assigned.
 
 ### Caching
 
@@ -266,6 +271,10 @@ See the corresponding directories for information on how to use the provided con
 * `charmm/` - CHARMM force fields and conversion tools
 
 # Changelog
+
+## 0.7.0 User-specified partial charges, SystemGenerator support for periodic and non-periodic topologies, and minor bugfixes
+
+* If `Molecule` objects contain nonzero partial charges, these are used instead of generating new partial charges
 
 ## 0.6.1 Updated README and minor bugfixes
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ See the corresponding directories for information on how to use the provided con
 ## 0.7.0 User-specified partial charges, SystemGenerator support for periodic and non-periodic topologies, and minor bugfixes
 
 * If `Molecule` objects contain nonzero partial charges, these are used instead of generating new partial charges
+* Fix bug in default `periodic_forcefield_kwargs` and `nonperiodic_forcefield_kwargs`
 
 ## 0.6.1 Updated README and minor bugfixes
 

--- a/openmmforcefields/generators/system_generators.py
+++ b/openmmforcefields/generators/system_generators.py
@@ -167,8 +167,8 @@ class SystemGenerator(object):
 
         # Cache force fields and settings to use
         self.forcefield_kwargs = forcefield_kwargs if forcefield_kwargs is not None else dict()
-        self.nonperiodic_forcefield_kwargs = nonperiodic_forcefield_kwargs if nonperiodic_forcefield_kwargs is not None else {'nonbondedCutoff' : app.NoCutoff}
-        self.periodic_forcefield_kwargs = periodic_forcefield_kwargs if periodic_forcefield_kwargs is not None else {'nonbondedCutoff' : app.PME}
+        self.nonperiodic_forcefield_kwargs = nonperiodic_forcefield_kwargs if nonperiodic_forcefield_kwargs is not None else {'nonbondedMethod' : app.NoCutoff}
+        self.periodic_forcefield_kwargs = periodic_forcefield_kwargs if periodic_forcefield_kwargs is not None else {'nonbondedMethod' : app.PME}
 
         # Create and cache a residue template generator
         from openmmforcefields.generators.template_generators import SmallMoleculeTemplateGenerator

--- a/openmmforcefields/generators/template_generators.py
+++ b/openmmforcefields/generators/template_generators.py
@@ -585,6 +585,7 @@ class GAFFTemplateGenerator(SmallMoleculeTemplateGenerator):
         # when openforcefield makes charge quantities consistently unit-bearing or
         # pure numbers.
         _logger.debug(f'Fixing partial charges...')
+        _logger.debug(f'{molecule.partial_charges}')
         from simtk import unit
         residue_charge = 0.0 * unit.elementary_charge
         total_charge = unit.sum(molecule.partial_charges)
@@ -593,6 +594,7 @@ class GAFFTemplateGenerator(SmallMoleculeTemplateGenerator):
         if sum_of_absolute_charge / unit.elementary_charge > 0.0:
             # Redistribute excess charge proportionally to absolute charge
             molecule.partial_charges += charge_deficit * abs(molecule.partial_charges) / sum_of_absolute_charge
+        _logger.debug(f'{molecule.partial_charges}')
 
         # Generate additional parameters if needed
         # TODO: Do we have to make sure that we don't duplicate existing parameters already loaded in the forcefield?

--- a/openmmforcefields/generators/template_generators.py
+++ b/openmmforcefields/generators/template_generators.py
@@ -1099,7 +1099,7 @@ class SMIRNOFFTemplateGenerator(SmallMoleculeTemplateGenerator):
         self._generate_unique_atom_names(molecule)
 
         # Determine which molecules (if any) contain user-specified partial charges that should be used
-        charge_from_molecules = None
+        charge_from_molecules = list()
         if self._molecule_has_user_charges(molecule):
             charge_from_molecules = [molecule]
             _logger.debug(f'Using user-provided charges because partial charges are nonzero...')

--- a/openmmforcefields/tests/test_template_generators.py
+++ b/openmmforcefields/tests/test_template_generators.py
@@ -214,7 +214,7 @@ class TestGAFFTemplateGenerator(unittest.TestCase):
         openmm_topology = molecule.to_topology().to_openmm()
         system = forcefield.createSystem(openmm_topology, nonbondedMethod=NoCutoff)
         # Ensure charges are no longer zero
-        assert not np.all(self.charges_from_system(system) == 0)
+        assert not np.all(self.charges_from_system(system) == 0), "System has zero charges despite molecule not being charged"
 
     def test_charge_from_molecules(self):
         """Test that user-specified partial charges are used if requested"""
@@ -231,7 +231,7 @@ class TestGAFFTemplateGenerator(unittest.TestCase):
         from simtk import unit
         molecule = self.molecules[0]
         charges = np.random.random([molecule.n_particles])
-        charges += (molecule.total_charge - charges.sum()) / molecule.n_particles 
+        charges += (molecule.total_charge - charges.sum()) / molecule.n_particles
         molecule.partial_charges = unit.Quantity(charges, unit.elementary_charge)
         assert not np.all(molecule.partial_charges / unit.elementary_charge == 0)
         # Add the molecule

--- a/openmmforcefields/tests/test_template_generators.py
+++ b/openmmforcefields/tests/test_template_generators.py
@@ -132,6 +132,97 @@ class TestGAFFTemplateGenerator(unittest.TestCase):
             system = forcefield.createSystem(openmm_topology, nonbondedMethod=NoCutoff)
             assert system.getNumParticles() == molecule.n_atoms
 
+    def charges_from_system(self, system):
+        """Extract dimensionless partial charges from a System
+
+        Parameters
+        ----------
+        system : simtk.openmm.System
+            The System from which partial charges are to be extracted
+
+        Returns
+        -------
+        charges : np.array of shape [n_particles]
+            The dimensionless partial charges (implicitly in units of elementary_charge)
+
+        """
+        import numpy as np
+        from simtk import unit
+        system_charges = list()
+        forces = { force.__class__.__name__ : force for force in system.getForces() }
+        for particle_index in range(system.getNumParticles()):
+            charge, sigma, epsilon = forces['NonbondedForce'].getParticleParameters(particle_index)
+            system_charges.append(charge / unit.elementary_charge)
+        system_charges = np.array(system_charges)
+
+        return system_charges
+
+    def charges_are_equal(self, system, molecule):
+        """Return True if partial charges are equal
+
+        Parameters
+        ----------
+        system : simtk.openmm.System
+            The System from which partial charges are to be extracted
+        molecule : openmmforcefield.topology.Molecule
+            The Molecule from which partial charges are to be extracted
+
+        Returns
+        -------
+        result : bool
+            True if the partial charges are equal, False if not
+        """
+        assert system.getNumParticles() == molecule.n_particles
+
+        system_charges = charges_from_system(system)
+
+        from simtk import unit
+        molecule_charges = molecule.partial_charges / unit.elementary_charge
+
+        return np.allclose(system_charges, molecule_charges)
+
+    def test_charge(self):
+        """Test that charges are nonzero after charging if the molecule does not contain user charges"""
+        # Create a generator that does not know about any molecules
+        generator = self.TEMPLATE_GENERATOR()
+        # Create a ForceField
+        from simtk.openmm.app import ForceField
+        forcefield = ForceField()
+        # Register the template generator
+        forcefield.registerTemplateGenerator(generator.generator)
+
+        # Check that parameterizing a molecule using user-provided charges produces expected charges
+        import numpy as np
+        from simtk import unit
+        molecule = self.molecules[0]
+        # Ensure partial charges are initially zero
+        assert np.all(molecule.partial_charges / unit.elementary_charge == 0)
+        from simtk.openmm.app import NoCutoff
+        openmm_topology = molecule.to_topology().to_openmm()
+        system = forcefield.createSystem(openmm_topology, nonbondedMethod=NoCutoff)
+        # Ensure charges are no longer zero
+        assert not np.all(self.charges_from_system(system) == 0)
+
+    def test_charge_from_molecules(self):
+        """Test that user-specified partial charges are used if requested"""
+        # Create a generator that does not know about any molecules
+        generator = self.TEMPLATE_GENERATOR()
+        # Create a ForceField
+        from simtk.openmm.app import ForceField
+        forcefield = ForceField()
+        # Register the template generator
+        forcefield.registerTemplateGenerator(generator.generator)
+
+        # Check that parameterizing a molecule using user-provided charges produces expected charges
+        import numpy as np
+        from simtk import unit
+        molecule = self.molecules[0]
+        molecule.partial_charges = unit.Quantity(np.random.random([molecule.n_particles], np.float32), unit.elementary_charge)
+        from simtk.openmm.app import NoCutoff
+        openmm_topology = molecule.to_topology().to_openmm()
+        system = forcefield.createSystem(openmm_topology, nonbondedMethod=NoCutoff)
+        assert self.charges_are_equal(system, molecule)
+
     def test_debug_ffxml(self):
         """Test that debug ffxml file is created when requested"""
         with tempfile.TemporaryDirectory() as tmpdirname:


### PR DESCRIPTION
This PR addresses #88 by having the residue template generators and `SystemGenerator` use user-specified charges from the `Molecule` objects if they are nonzero, generating charges only if they are all zero instead.

This also fixes an issue with default periodic and nonperiodic kwargs.